### PR TITLE
Criação do banco de dados

### DIFF
--- a/database/schemas.sql
+++ b/database/schemas.sql
@@ -1,0 +1,45 @@
+DROP DATABASE IF EXISTS ascan_subscriptions;
+
+CREATE DATABASE ascan_subscriptions;
+
+USE ascan_subscriptions;
+
+CREATE TABLE user(
+    id        INT NOT NULL AUTO_INCREMENT,
+    full_name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE status(
+    id          INT NOT NULL AUTO_INCREMENT,
+    status_name VARCHAR(255),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE subscription(
+    id         INT NOT NULL AUTO_INCREMENT,
+    user_id    INT NOT NULL,
+    status_id  INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL,
+    PRIMARY KEY(id),
+    FOREIGN KEY(user_id) 
+        REFERENCES user(id)
+        ON DELETE CASCADE,
+    FOREIGN KEY(status_id)
+         REFERENCES status(id)
+         ON DELETE CASCADE
+);
+
+
+CREATE TABLE event_hisotry(
+    id              INT NOT NULL AUTO_INCREMENT,
+    subscription_id INT NOT NULL,
+    type            VARCHAR(255) NOT NULL,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(id),
+    FOREIGN KEY(subscription_id)
+        REFERENCES subscription(id)
+        ON DELETE CASCADE
+);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
 version: "3.9"
-
 services:  
   mysql:
     image: mysql:latest
@@ -12,9 +11,7 @@ services:
       - '3306'
     volumes:
       - db:/var/lib/mysql
-      - ./scripts/schemas.sql:/docker-entrypoint-initdb.d/init.sql
-    command: ["mysqld", "--init-file=/docker-entrypoint-initdb.d/init.sql"]
-  
+      - ./database/schemas.sql:/docker-entrypoint-initdb.d/init.sql
 volumes:
   db:
     driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:  
+  mysql:
+    image: mysql:latest
+    container_name: ascan_subscriptions_mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: 'p4ss@word'
+    ports:
+      - '3306:3306'
+    expose:
+      - '3306'
+    volumes:
+      - db:/var/lib/mysql
+      - ./scripts/schemas.sql:/docker-entrypoint-initdb.d/init.sql
+    command: ["mysqld", "--init-file=/docker-entrypoint-initdb.d/init.sql"]
+  
+volumes:
+  db:
+    driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     image: mysql:latest
     cap_add:
       - "SYS_NICE"
+    restart: always
     container_name: ascan_subscriptions_mysql
     environment:
       MYSQL_ROOT_PASSWORD: 'p4ss@word'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,8 @@ version: "3.9"
 services:  
   mysql:
     image: mysql:latest
+    cap_add:
+      - "SYS_NICE"
     container_name: ascan_subscriptions_mysql
     environment:
       MYSQL_ROOT_PASSWORD: 'p4ss@word'


### PR DESCRIPTION
Essa PR adiciona os scripts de criação do banco de dados  e o arquivo docker-compose.yaml para criação de um container MySQL com criação das tabelas automatizada.