### PR TITLE
Criação da instância do RabbitMQ

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,26 @@ services:
     volumes:
       - db:/var/lib/mysql
       - ./database/schemas.sql:/docker-entrypoint-initdb.d/init.sql
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: 'rabbitmq'
+    ports:
+        - 5672:5672
+        - 15672:15672
+    volumes:
+        - rabbitmq_data:/var/lib/rabbitmq/
+        - rabbitmq_logs:/var/log/rabbitmq
+    networks:
+        - rabbitmq_network
+
+networks:
+  rabbitmq_network:
+    driver: bridge
+    
 volumes:
   db:
+    driver: local
+  rabbitmq_data:
+    driver: local
+  rabbitmq_logs:
     driver: local


### PR DESCRIPTION
Essa PR adiciona a criação de uma instância do RabbitMQ em um container utilizando o arquivo docker-compose.yaml