### PR TITLE
Refatoração dos endpoints

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
     image: mysql:latest
     cap_add:
       - "SYS_NICE"
-    restart: always
     container_name: mysql
     environment:
       MYSQL_ROOT_PASSWORD: "p4ss@word"
@@ -43,7 +42,6 @@ services:
   producer:
     container_name: "producer"
     build: producer/.
-    image: producer
     ports:
       - "5000:5000"
     expose:
@@ -63,11 +61,11 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
+    restart: always
 
   consumer:
     container_name: "consumer"
     build: consumer/.
-    image: consumer
     environment:
       #mysql
       MYSQL_HOST: "mysql"
@@ -86,6 +84,8 @@ services:
         condition: service_healthy
       mysql: 
         condition: service_healthy
+    restart: always
+
 
 networks:
   rabbitmq_network:

--- a/producer/api/router/subscription.py
+++ b/producer/api/router/subscription.py
@@ -20,7 +20,7 @@ QUEUE_RESTARTED = "RESTARTED"
 
 blueprint = Blueprint("subscriptions", __name__)
 
-@blueprint.route("/create", methods=["POST"])
+@blueprint.route("/", methods=["POST"])
 def create() :
     request_data = request.json
     schema       = CreateSubscriptionSchema()

--- a/producer/api/router/subscription.py
+++ b/producer/api/router/subscription.py
@@ -9,7 +9,7 @@ from marshmallow import Schema, ValidationError
 from pika.exceptions import AMQPError
 
 from api.schema.subscription import CreateSubscriptionSchema, UpdateSubscriptionStatusSchema
-from api.service.connector import Connector
+from api.service.connector import TIMEOUT, Connector
 
 DEFAULT_EXCHANGE = "SUBSCRIPTION"
 DEFAULT_EXCHANGE_TYPE = "direct"
@@ -75,6 +75,10 @@ def index():
 def send_request(request: Any, producer: Connector) -> None:
     try:
         response = producer.publish(request)
+        
+        if (response == None):
+            return Response(response=json.dumps("The server did not send a response"), status=HTTPStatus.REQUEST_TIMEOUT)
+        
         return Response(response=json.dumps(response), status=HTTPStatus.OK)
 
     except AMQPError as err:

--- a/producer/api/router/subscription.py
+++ b/producer/api/router/subscription.py
@@ -8,7 +8,7 @@ from flask import Blueprint, Response, request
 from marshmallow import Schema, ValidationError
 from pika.exceptions import AMQPError
 
-from api.schema.subscription import CreateSubscriptionSchema, UpdateSubscriptionSchema
+from api.schema.subscription import CreateSubscriptionSchema, UpdateSubscriptionStatusSchema
 from api.service.connector import Connector
 
 DEFAULT_EXCHANGE = "SUBSCRIPTION"
@@ -18,47 +18,64 @@ QUEUE_PURCHASED = "PURCHASED"
 QUEUE_CANCELED  = "CANCELED"
 QUEUE_RESTARTED = "RESTARTED"
 
+ACTIVE    = 1
+CANCELED  = 2
+
 blueprint = Blueprint("subscriptions", __name__)
 
 @blueprint.route("/", methods=["POST"])
 def create() :
-    request_data = request.json
-    schema       = CreateSubscriptionSchema()
-    connector    = Connector(QUEUE_PURCHASED, DEFAULT_EXCHANGE, DEFAULT_EXCHANGE_TYPE)
+    try:
+        request_data = request.json
+        schema       = CreateSubscriptionSchema()
+        request_data = schema.load(request_data)
 
-    return send_request(schema, request_data, connector)
+        connector    = Connector(QUEUE_PURCHASED, DEFAULT_EXCHANGE, DEFAULT_EXCHANGE_TYPE)
 
-@blueprint.route("/cancel/<int:id>", methods=["PUT"])
-def cancel(id) :
-    request_data = { "subscription_id": id }
+        return send_request(request_data, connector)
 
-    schema    = UpdateSubscriptionSchema()
-    connector = Connector(QUEUE_CANCELED, DEFAULT_EXCHANGE, DEFAULT_EXCHANGE_TYPE)
+    except ValidationError as err:
+        return Response(response=json.dumps(err.messages), status=HTTPStatus.BAD_REQUEST)
+
+
+@blueprint.route("/<int:id>/status", methods=["PUT"])
+def update(id) :
+    try:
+        request_data                    = request.json
+        request_data["subscription_id"] = id 
+        
+        schema       = UpdateSubscriptionStatusSchema()
+        request_data = schema.load(request_data)
+
+        if ("canceled" not in request_data):
+            request_data["canceled"] = False
+
+        if ("restarted" not in request_data):
+            request_data["restarted"] = False
+
+        if(request_data["canceled"] and request_data["restarted"] ):
+            raise ValidationError(field_name="canceled",message="The fields 'canceled' and 'restarted' cant be TRUE at the same time !")
+
+        if(not request_data["canceled"] and not request_data["restarted"] ):
+            raise ValidationError(message="The fields 'canceled' and 'restarted' cant be FALSE at the same time !")
+
+        queue = QUEUE_CANCELED if request_data["canceled"] else QUEUE_RESTARTED
+        connector = Connector(queue, DEFAULT_EXCHANGE, DEFAULT_EXCHANGE_TYPE)
+        
+        return send_request(request_data, connector)
     
-    return send_request(schema, request_data, connector)
+    except ValidationError as err:
+        return Response(response=json.dumps(err.messages), status=HTTPStatus.BAD_REQUEST)
 
-@blueprint.route("/restart/<int:id>", methods=["PUT"])
-def restart(id) :
-    request_data = { "subscription_id": id }
-    
-    schema    = UpdateSubscriptionSchema()
-    connector = Connector(QUEUE_RESTARTED, DEFAULT_EXCHANGE, DEFAULT_EXCHANGE_TYPE)
-
-    return send_request(schema, request_data, connector)
 
 @blueprint.route("/") 
 def index():
     return Response(response="OK", status=HTTPStatus.OK, headers={"Content-Type": "application/json"})
 
-def send_request(schema: Schema, request: Any, producer: Connector) -> None:
+def send_request(request: Any, producer: Connector) -> None:
     try:
-        result  = schema.load(request)
-        response = producer.publish(result)
-        
+        response = producer.publish(request)
         return Response(response=json.dumps(response), status=HTTPStatus.OK)
-
-    except ValidationError as err:
-        return Response(response=json.dumps(err.messages), status=HTTPStatus.BAD_REQUEST)
 
     except AMQPError as err:
         return Response(json.dumps(err), status=HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/producer/api/schema/subscription.py
+++ b/producer/api/schema/subscription.py
@@ -3,5 +3,7 @@ from marshmallow import Schema, fields
 class CreateSubscriptionSchema(Schema):
     user_id    = fields.Int(required=True)
 
-class UpdateSubscriptionSchema(Schema):
-    id = fields.Number(required=True)
+class UpdateSubscriptionStatusSchema(Schema):
+    subscription_id = fields.Number(required=True)
+    canceled        = fields.Bool(required=False, default=False)
+    restarted       = fields.Bool(required=False, default=False)


### PR DESCRIPTION
Essa PR refatora os endpoinst de criação, cancelamento e reinicialização das subscriptions e adiciona timeout de resposta do consumer.

- Foram removidos os verbos nas urls dos enpoints
- O PUT foi adotado como método padrão para as rotas de atualização
- Foi adicionado um timeout padrão de 20 segundos 
- Foi adicionado um restart automático nos containers para caso de falha